### PR TITLE
DSL refactors

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -20,14 +20,18 @@ module Wafalyzer
         /__tough_id/i,
       )
 
-    matches_header %w(Server Set-Cookie), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(Server Set-Cookie), PATTERN
+      matches_body PATTERN
+    end
   end
 
   class Waf::SuperToughWaf < Waf
     register product: "***"
 
-    valid_status :forbidden
-    matches_header %w(Server Cookies Set-Cookie), /__s0m00cht0ugh/
+    builder do
+      valid_status :forbidden
+      matches_header %w(Server Cookies Set-Cookie), /__s0m00cht0ugh/
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,7 +12,7 @@ end
 
 module Wafalyzer
   class Waf::ToughWaf < Waf
-    product "Tough XTreme Super Pro Plus Hardcore 3000 WAF Solution"
+    register product: "Tough XTreme Super Pro Plus Hardcore 3000 WAF Solution"
 
     PATTERN =
       Regex.union(
@@ -25,7 +25,7 @@ module Wafalyzer
   end
 
   class Waf::SuperToughWaf < Waf
-    product "***"
+    register product: "***"
 
     valid_status :forbidden
     matches_header %w(Server Cookies Set-Cookie), /__s0m00cht0ugh/

--- a/spec/wafalyzer/waf_spec.cr
+++ b/spec/wafalyzer/waf_spec.cr
@@ -1,7 +1,7 @@
 require "../spec_helper"
 
 Spectator.describe Wafalyzer::Waf do
-  subject { Wafalyzer::Waf::ToughWaf.new }
+  subject { Wafalyzer::Waf::ToughWaf.instance }
 
   describe "#product" do
     it "returns an non-empty string" do
@@ -11,8 +11,8 @@ Spectator.describe Wafalyzer::Waf do
   end
 
   describe "#to_s" do
-    it "aliases to #product?" do
-      expect(&.to_s).to eq(subject.product?)
+    it "aliases to #product" do
+      expect(&.to_s).to eq(subject.product)
     end
   end
 
@@ -58,7 +58,7 @@ Spectator.describe Wafalyzer::Waf do
     end
 
     context "with matching status" do
-      subject { Wafalyzer::Waf::SuperToughWaf.new }
+      subject { Wafalyzer::Waf::SuperToughWaf.instance }
 
       let(response) do
         HTTP::Client::Response.new(
@@ -73,7 +73,7 @@ Spectator.describe Wafalyzer::Waf do
     end
 
     context "with non-matching status" do
-      subject { Wafalyzer::Waf::SuperToughWaf.new }
+      subject { Wafalyzer::Waf::SuperToughWaf.instance }
 
       let(response) do
         HTTP::Client::Response.new(

--- a/spec/wafalyzer_spec.cr
+++ b/spec/wafalyzer_spec.cr
@@ -1,8 +1,8 @@
 require "./spec_helper"
 
 Spectator.describe Wafalyzer do
-  let(wafs) { subject.wafs }
-  let(tough_waf) { wafs.find(&.class.==(Wafalyzer::Waf::ToughWaf)) }
+  let(wafs) { Wafalyzer::Waf.instances }
+  let(tough_waf) { wafs[Wafalyzer::Waf::ToughWaf] }
   let(tough_waf_server) do
     HTTP::Server.new do |context|
       context.response
@@ -14,10 +14,9 @@ Spectator.describe Wafalyzer do
 
   describe ".wafs" do
     it "return an array of all loaded Waf classes" do
-      expect(wafs).to be_a(Array(Wafalyzer::Waf))
+      expect(wafs).to be_a(Hash(Wafalyzer::Waf.class, Wafalyzer::Waf))
       expect(wafs).to_not be_empty
       expect(tough_waf).to_not be_nil
-      expect(wafs).to contain(tough_waf)
     end
   end
 

--- a/src/wafalyzer.cr
+++ b/src/wafalyzer.cr
@@ -130,7 +130,7 @@ module Wafalyzer
     uri, response =
       exec_request_with_redirections(uri, method, headers, body, user_agent)
 
-    detected = wafs.select(&.matches?(response))
+    detected = Waf.detect(response)
     Log.debug {
       if detected.empty?
         "No WAFs detected"

--- a/src/wafalyzer/waf.cr
+++ b/src/wafalyzer/waf.cr
@@ -51,7 +51,7 @@ module Wafalyzer
     include DSL
 
     # Full name of the WAF solution being defined
-    property product : String
+    getter product : String
 
     def initialize(@product)
       super()

--- a/src/wafalyzer/waf.cr
+++ b/src/wafalyzer/waf.cr
@@ -42,101 +42,31 @@ module Wafalyzer
       find(self)
     end
 
+    def self.builder
+      with instance yield instance
+    end
+
+    include DSL
+
+    # Full name of the WAF solution being defined
+    property product : String
+
+    def initialize(@product)
+      super()
+    end
+
+    def initialize
+      initialize(self.class.instance.product)
+    end
+
+    def_clone
+
     def to_s(io : IO) : Nil
       io << product
     end
 
     def to_json(json : JSON::Builder)
       {product: product}.to_json(json)
-    end
-
-    # Returns `true` if given *response* matches defined
-    # assertions, `false` otherwise.
-    def matches?(response : HTTP::Client::Response) : Bool
-      return false unless valid_status?(response)
-      return true if matches_headers?(response)
-      return true if matches_body?(response)
-      false
-    end
-
-    protected def valid_status?(response : HTTP::Client::Response) : Bool
-      @@status.empty? || @@status.any?(&.==(response.status))
-    end
-
-    protected def matches_headers?(response : HTTP::Client::Response) : Bool
-      headers = response.headers
-
-      @@headers.each do |name, pattern|
-        case name
-        when "*any-key*"
-          headers.each do |key, _|
-            if key =~ pattern
-              Log.debug &.emit("Found *any-key* header match", {
-                key:     key,
-                pattern: pattern.to_s,
-                matches: $~.to_a,
-              })
-              return true
-            end
-          end
-        when "*any-value*"
-          headers.each do |key, values|
-            if value = values.find(&.=~(pattern))
-              Log.debug &.emit("Found *any-value* header match", {
-                key:     key,
-                value:   value,
-                pattern: pattern.to_s,
-                matches: $~.to_a,
-              })
-              return true
-            end
-          end
-        when "*any-key-value*"
-          headers.each do |key, values|
-            if key =~ pattern
-              Log.debug &.emit("Found *any-key-value* header key match", {
-                key:     key,
-                pattern: pattern.to_s,
-                matches: $~.to_a,
-              })
-              return true
-            end
-            if value = values.find(&.=~(pattern))
-              Log.debug &.emit("Found *any-key-value* header value match", {
-                key:     key,
-                value:   value,
-                pattern: pattern.to_s,
-                matches: $~.to_a,
-              })
-              return true
-            end
-          end
-        else
-          if (value = headers[name]?) =~ pattern
-            Log.debug &.emit("Found header match", {
-              key:     name,
-              value:   value,
-              pattern: pattern.to_s,
-              matches: $~.to_a,
-            })
-            return true
-          end
-        end
-      end
-      false
-    end
-
-    protected def matches_body?(response : HTTP::Client::Response) : Bool
-      @@body.try do |pattern|
-        if response.body? =~ pattern
-          Log.debug &.emit("Found body match", {
-            pattern: pattern.to_s,
-            matches: $~.to_a,
-          })
-          return true
-        end
-      end
-      false
     end
   end
 end

--- a/src/wafalyzer/waf/dsl.cr
+++ b/src/wafalyzer/waf/dsl.cr
@@ -34,12 +34,12 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will match on ANY of the added values.
-    def valid_status(status : HTTP::Status)
+    protected def valid_status(status : HTTP::Status)
       self.valid_status << status
     end
 
     # :ditto:
-    def valid_status(code : Int32)
+    protected def valid_status(code : Int32)
       valid_status HTTP::Status.new(code)
     end
 
@@ -72,18 +72,18 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def matches_header(name : String, value : Regex)
+    protected def matches_header(name : String, value : Regex)
       matches_headers[name] =
         matches_headers[name]?.try(&.+(value)) || value
     end
 
     # :ditto:
-    def matches_header(name : String, value : String)
+    protected def matches_header(name : String, value : String)
       matches_header name, Regex.new("\\A#{Regex.escape(value)}\\z")
     end
 
     # :ditto:
-    def matches_header(names : Enumerable(String), value : Regex | String)
+    protected def matches_header(names : Enumerable(String), value : Regex | String)
       names.each { |name| matches_header name, value }
     end
 
@@ -104,7 +104,7 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def matches_header(name : String | Enumerable(String))
+    protected def matches_header(name : String | Enumerable(String))
       matches_header name, /.+/
     end
 
@@ -121,7 +121,7 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def matches_any_header_key(value : Regex | String)
+    protected def matches_any_header_key(value : Regex | String)
       matches_header "*any-key*", value
     end
 
@@ -138,7 +138,7 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def matches_any_header_value(value : Regex | String)
+    protected def matches_any_header_value(value : Regex | String)
       matches_header "*any-value*", value
     end
 
@@ -155,7 +155,7 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def matches_any_header(value : Regex | String)
+    protected def matches_any_header(value : Regex | String)
       matches_header "*any-key-value*", value
     end
 
@@ -172,7 +172,7 @@ module Wafalyzer
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def matches_body(value : Regex)
+    protected def matches_body(value : Regex)
       self.matches_body =
         matches_body.try(&.+(value)) || value
     end

--- a/src/wafalyzer/waf/dsl.cr
+++ b/src/wafalyzer/waf/dsl.cr
@@ -1,14 +1,10 @@
 module Wafalyzer
   abstract class Waf
     # Full name of the WAF solution being defined
-    class_property! product : String
+    property product : String
 
-    # :ditto:
-    def self.product(@@product)
+    def initialize(@product)
     end
-
-    delegate :product, :product?,
-      to: self.class
 
     @@status = [] of HTTP::Status
 

--- a/src/wafalyzer/waf/dsl.cr
+++ b/src/wafalyzer/waf/dsl.cr
@@ -1,12 +1,22 @@
+require "./matcher"
+
 module Wafalyzer
-  abstract class Waf
-    # Full name of the WAF solution being defined
-    property product : String
+  abstract class Waf; end
 
-    def initialize(@product)
+  module Waf::DSL
+    include Matcher
+
+    protected getter valid_status = [] of HTTP::Status
+    protected getter matches_headers = {} of String => Regex
+    protected property matches_body : Regex?
+
+    def initialize
+      return unless instance = self.class.instance?
+
+      @valid_status = instance.valid_status.dup
+      @matches_headers = instance.matches_headers.dup
+      @matches_body = instance.matches_body.dup
     end
-
-    @@status = [] of HTTP::Status
 
     # Declaration that returned HTTP status must match
     # the given *status*, otherwise rest of the rules
@@ -14,64 +24,66 @@ module Wafalyzer
     #
     # ```
     # class Waf::Foo < Waf
-    #   valid_status :forbidden
-    #   # or
-    #   valid_status 403
+    #   builder do
+    #     valid_status :forbidden
+    #     # or
+    #     valid_status 403
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will match on ANY of the added values.
-    def self.valid_status(status : HTTP::Status)
-      @@status << status
+    def valid_status(status : HTTP::Status)
+      self.valid_status << status
     end
 
     # :ditto:
-    def self.valid_status(code : Int32)
+    def valid_status(code : Int32)
       valid_status HTTP::Status.new(code)
     end
-
-    @@headers = {} of String => Regex
 
     # Declaration that returned HTTP response header *name*
     # must match the given *value* pattern.
     #
     # ```
     # class Waf::Foo < Waf
-    #   # exact match, case sensitive
-    #   matches_header "Server", "Apache"
+    #   builder do
+    #     # exact match, case sensitive
+    #     matches_header "Server", "Apache"
     #
-    #   # exact match, case insensitive
-    #   matches_header "Server", /^apache$/i
+    #     # exact match, case insensitive
+    #     matches_header "Server", /^apache$/i
     #
-    #   # partial match, case insensitive
-    #   matches_header "Server", /apache/i
+    #     # partial match, case insensitive
+    #     matches_header "Server", /apache/i
     #
-    #   # asserts the pattern for multiple headers at once
-    #   matches_header %w(Cookie Set-Cookie), /__unique_id/
+    #     # asserts the pattern for multiple headers at once
+    #     matches_header %w(Cookie Set-Cookie), /__unique_id/
     #
-    #   # asserts that "X-Foo" header is not empty
-    #   matches_header "X-Foo"
+    #     # asserts that "X-Foo" header is not empty
+    #     matches_header "X-Foo"
     #
-    #   # same as above, but for multiple headers at once
-    #   matches_header %w(X-Foo X-Bar X-Baz)
+    #     # same as above, but for multiple headers at once
+    #     matches_header %w(X-Foo X-Bar X-Baz)
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def self.matches_header(name : String, value : Regex)
-      @@headers[name] =
-        @@headers[name]?.try(&.+(value)) || value
+    def matches_header(name : String, value : Regex)
+      matches_headers[name] =
+        matches_headers[name]?.try(&.+(value)) || value
     end
 
     # :ditto:
-    def self.matches_header(name : String, value : String)
+    def matches_header(name : String, value : String)
       matches_header name, Regex.new("\\A#{Regex.escape(value)}\\z")
     end
 
     # :ditto:
-    def self.matches_header(names : Enumerable(String), value : Regex | String)
+    def matches_header(names : Enumerable(String), value : Regex | String)
       names.each { |name| matches_header name, value }
     end
 
@@ -80,17 +92,19 @@ module Wafalyzer
     #
     # ```
     # class Waf::Foo < Waf
-    #   # asserts that "X-Foo" header is not empty
-    #   matches_header "X-Foo"
+    #   builder do
+    #     # asserts that "X-Foo" header is not empty
+    #     matches_header "X-Foo"
     #
-    #   # same as above, but for multiple headers at once
-    #   matches_header %w(X-Foo X-Bar X-Baz)
+    #     # same as above, but for multiple headers at once
+    #     matches_header %w(X-Foo X-Bar X-Baz)
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def self.matches_header(name : String | Enumerable(String))
+    def matches_header(name : String | Enumerable(String))
       matches_header name, /.+/
     end
 
@@ -99,13 +113,15 @@ module Wafalyzer
     #
     # ```
     # class Waf::Foo < Waf
-    #   matches_any_header_key /X-Foo-\d+/i
+    #   builder do
+    #     matches_any_header_key /X-Foo-\d+/i
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def self.matches_any_header_key(value : Regex | String)
+    def matches_any_header_key(value : Regex | String)
       matches_header "*any-key*", value
     end
 
@@ -114,13 +130,15 @@ module Wafalyzer
     #
     # ```
     # class Waf::Foo < Waf
-    #   matches_any_header_value "waf.foo.com"
+    #   builder do
+    #     matches_any_header_value "waf.foo.com"
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def self.matches_any_header_value(value : Regex | String)
+    def matches_any_header_value(value : Regex | String)
       matches_header "*any-value*", value
     end
 
@@ -129,32 +147,34 @@ module Wafalyzer
     #
     # ```
     # class Waf::Foo < Waf
-    #   matches_any_header /SuperToughWaf/i
+    #   builder do
+    #     matches_any_header /SuperToughWaf/i
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def self.matches_any_header(value : Regex | String)
+    def matches_any_header(value : Regex | String)
       matches_header "*any-key-value*", value
     end
-
-    @@body : Regex?
 
     # Declaration that returned HTTP body must match
     # the given *value* pattern.
     #
     # ```
     # class Waf::Foo < Waf
-    #   matches_body /<title>403 Forbidden<\/title>/i
+    #   builder do
+    #     matches_body /<title>403 Forbidden<\/title>/i
+    #   end
     # end
     # ```
     #
     # NOTE: Additive - calling this method multiple times
     # will create an union with the already existing value.
-    def self.matches_body(value : Regex)
-      @@body =
-        @@body.try(&.+(value)) || value
+    def matches_body(value : Regex)
+      self.matches_body =
+        matches_body.try(&.+(value)) || value
     end
   end
 end

--- a/src/wafalyzer/waf/matcher.cr
+++ b/src/wafalyzer/waf/matcher.cr
@@ -1,0 +1,91 @@
+module Wafalyzer
+  abstract class Waf; end
+
+  module Waf::Matcher
+    protected def valid_status?(response : HTTP::Client::Response) : Bool
+      valid_status.empty? || valid_status.any?(&.==(response.status))
+    end
+
+    protected def matches_headers?(response : HTTP::Client::Response) : Bool
+      headers = response.headers
+      matches_headers.each do |name, pattern|
+        case name
+        when "*any-key*"
+          headers.each do |key, _|
+            if key =~ pattern
+              Log.debug &.emit("Found *any-key* header match", {
+                key:     key,
+                pattern: pattern.to_s,
+                matches: $~.to_a,
+              })
+              return true
+            end
+          end
+        when "*any-value*"
+          headers.each do |key, values|
+            if value = values.find(&.=~(pattern))
+              Log.debug &.emit("Found *any-value* header match", {
+                key:     key,
+                value:   value,
+                pattern: pattern.to_s,
+                matches: $~.to_a,
+              })
+              return true
+            end
+          end
+        when "*any-key-value*"
+          headers.each do |key, values|
+            if key =~ pattern
+              Log.debug &.emit("Found *any-key-value* header key match", {
+                key:     key,
+                pattern: pattern.to_s,
+                matches: $~.to_a,
+              })
+              return true
+            end
+            if value = values.find(&.=~(pattern))
+              Log.debug &.emit("Found *any-key-value* header value match", {
+                key:     key,
+                value:   value,
+                pattern: pattern.to_s,
+                matches: $~.to_a,
+              })
+              return true
+            end
+          end
+        else
+          if (value = headers[name]?) =~ pattern
+            Log.debug &.emit("Found header match", {
+              key:     name,
+              value:   value,
+              pattern: pattern.to_s,
+              matches: $~.to_a,
+            })
+            return true
+          end
+        end
+      end
+      false
+    end
+
+    protected def matches_body?(response : HTTP::Client::Response) : Bool
+      matches_body.try do |pattern|
+        if response.body? =~ pattern
+          Log.debug &.emit("Found body match", {
+            pattern: pattern.to_s,
+            matches: $~.to_a,
+          })
+          return true
+        end
+      end
+      false
+    end
+
+    # Returns `true` if given *response* matches defined
+    # assertions, `false` otherwise.
+    def matches?(response : HTTP::Client::Response) : Bool
+      valid_status?(response) &&
+        (matches_headers?(response) || matches_body?(response))
+    end
+  end
+end

--- a/src/wafalyzer/wafs/360.cr
+++ b/src/wafalyzer/wafs/360.cr
@@ -11,7 +11,9 @@ module Wafalyzer
         /transfer.is.blocked/i,
       )
 
-    matches_header %w(Server X-Powered-By-360wzb), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(Server X-Powered-By-360wzb), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/360.cr
+++ b/src/wafalyzer/wafs/360.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Waf360 < Waf
-    product "360 Web Application Firewall (360)"
+    register product: "360 Web Application Firewall (360)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/aesecure.cr
+++ b/src/wafalyzer/wafs/aesecure.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::AeSecure < Waf
-    product "aeSecure (WAF)"
+    register product: "aeSecure (WAF)"
 
     PATTERN =
       /aesecure.denied.png/i

--- a/src/wafalyzer/wafs/aesecure.cr
+++ b/src/wafalyzer/wafs/aesecure.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /aesecure.denied.png/i
 
-    matches_header "AeSecure-Code"
-    matches_body PATTERN
+    builder do
+      matches_header "AeSecure-Code"
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/airlock.cr
+++ b/src/wafalyzer/wafs/airlock.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Airlock < Waf
-    product "Airlock (Phion/Ergon)"
+    register product: "Airlock (Phion/Ergon)"
 
     matches_header "Set-Cookie", /\Aal[.-]?(sess|lb)=?/i
   end

--- a/src/wafalyzer/wafs/airlock.cr
+++ b/src/wafalyzer/wafs/airlock.cr
@@ -2,6 +2,8 @@ module Wafalyzer
   class Waf::Airlock < Waf
     register product: "Airlock (Phion/Ergon)"
 
-    matches_header "Set-Cookie", /\Aal[.-]?(sess|lb)=?/i
+    builder do
+      matches_header "Set-Cookie", /\Aal[.-]?(sess|lb)=?/i
+    end
   end
 end

--- a/src/wafalyzer/wafs/akamai.cr
+++ b/src/wafalyzer/wafs/akamai.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Akamai < Waf
-    product "AkamaiGhost Website Protection (Akamai Global Host)"
+    register product: "AkamaiGhost Website Protection (Akamai Global Host)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/akamai.cr
+++ b/src/wafalyzer/wafs/akamai.cr
@@ -9,7 +9,9 @@ module Wafalyzer
         /ak.bmsc./i,
       )
 
-    matches_header %w(Server Set-Cookie), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(Server Set-Cookie), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/alertlogic.cr
+++ b/src/wafalyzer/wafs/alertlogic.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::AlertLogic < Waf
-    product "Alert Logic (SIEMless Threat Management)"
+    register product: "Alert Logic (SIEMless Threat Management)"
 
     PATTERNS = {
       /.>requested.url.cannot.be.found<./i,

--- a/src/wafalyzer/wafs/aliyundun.cr
+++ b/src/wafalyzer/wafs/aliyundun.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::AliYunDun < Waf
-    product "AliYunDun (WAF)"
+    register product: "AliYunDun (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/aliyundun.cr
+++ b/src/wafalyzer/wafs/aliyundun.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /http(s)?:\/\/(www.)?aliyun.(com|net)/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/anquanbao.cr
+++ b/src/wafalyzer/wafs/anquanbao.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /.aqb_cc.error./i
 
-    matches_body PATTERN
-    matches_any_header_value PATTERN
+    builder do
+      matches_body PATTERN
+      matches_any_header_value PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/anquanbao.cr
+++ b/src/wafalyzer/wafs/anquanbao.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Anquanbao < Waf
-    product "Anquanbao Web Application Firewall (Anquanbao)"
+    register product: "Anquanbao Web Application Firewall (Anquanbao)"
 
     PATTERN =
       /.aqb_cc.error./i

--- a/src/wafalyzer/wafs/anyu.cr
+++ b/src/wafalyzer/wafs/anyu.cr
@@ -9,7 +9,9 @@ module Wafalyzer
         /anyu-?.the.green.channel/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
 
     def matches?(response : HTTP::Client::Response) : Bool
       event_id = response.headers["WZWS-RAY"]?.presence

--- a/src/wafalyzer/wafs/anyu.cr
+++ b/src/wafalyzer/wafs/anyu.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Anyu < Waf
-    product "AnYu Web Application Firewall (Anyu Technologies)"
+    register product: "AnYu Web Application Firewall (Anyu Technologies)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/apache.cr
+++ b/src/wafalyzer/wafs/apache.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Apache < Waf
-    product "Apache Generic Protection"
+    register product: "Apache Generic Protection"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/apache.cr
+++ b/src/wafalyzer/wafs/apache.cr
@@ -11,8 +11,10 @@ module Wafalyzer
         /<title>403 Forbidden<\/title>/i,
       )
 
-    valid_status :forbidden
-    matches_header "Server", PATTERN
-    matches_body PATTERN
+    builder do
+      valid_status :forbidden
+      matches_header "Server", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/armor.cr
+++ b/src/wafalyzer/wafs/armor.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /blocked.by.website.protection.from.armour/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/armor.cr
+++ b/src/wafalyzer/wafs/armor.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Armor < Waf
-    product "Armor Protection (Armor Defense)"
+    register product: "Armor Protection (Armor Defense)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/asm.cr
+++ b/src/wafalyzer/wafs/asm.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /the.requested.url.was.rejected..please.consult.with.your.administrator./i
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/asm.cr
+++ b/src/wafalyzer/wafs/asm.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ASM < Waf
-    product "Application Security Manager (F5 Networks)"
+    register product: "Application Security Manager (F5 Networks)"
 
     PATTERN =
       /the.requested.url.was.rejected..please.consult.with.your.administrator./i

--- a/src/wafalyzer/wafs/aspnet.cr
+++ b/src/wafalyzer/wafs/aspnet.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ASPNet < Waf
-    product "ASP.NET Generic Website Protection (Microsoft)"
+    register product: "ASP.NET Generic Website Protection (Microsoft)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/ats.cr
+++ b/src/wafalyzer/wafs/ats.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /ats/i,
       )
 
-    matches_header %w(Via Server), PATTERN
+    builder do
+      matches_header %w(Via Server), PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/ats.cr
+++ b/src/wafalyzer/wafs/ats.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ATS < Waf
-    product "Apache Traffic Server (ATS web proxy)"
+    register product: "Apache Traffic Server (ATS web proxy)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/aws.cr
+++ b/src/wafalyzer/wafs/aws.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /<Error><Code>AccessDenied<.Code>/i,
       )
 
-    matches_header %w(Server X-Powered-By Set-Cookie), /x.amz.(id.\d+|request.id)/i
-    matches_body PATTERN
+    builder do
+      matches_header %w(Server X-Powered-By Set-Cookie), /x.amz.(id.\d+|request.id)/i
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/aws.cr
+++ b/src/wafalyzer/wafs/aws.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::AWS < Waf
-    product "Amazon Web Services Web Application Firewall (Amazon)"
+    register product: "Amazon Web Services Web Application Firewall (Amazon)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/baidu.cr
+++ b/src/wafalyzer/wafs/baidu.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Baidu < Waf
-    product "Yunjiasu Web Application Firewall (Baidu)"
+    register product: "Yunjiasu Web Application Firewall (Baidu)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/baidu.cr
+++ b/src/wafalyzer/wafs/baidu.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /yunjiasu.nginx/i,
       )
 
-    matches_header %w(X-Server Server), PATTERN
+    builder do
+      matches_header %w(X-Server Server), PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/barikode.cr
+++ b/src/wafalyzer/wafs/barikode.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Barikode < Waf
-    product "Barikode Web Application Firewall"
+    register product: "Barikode Web Application Firewall"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/barikode.cr
+++ b/src/wafalyzer/wafs/barikode.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /<h\d{1}>forbidden.access<.h\d{1}>/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/barracuda.cr
+++ b/src/wafalyzer/wafs/barracuda.cr
@@ -9,7 +9,9 @@ module Wafalyzer
         /barracuda.networks.{1,2}inc/i,
       )
 
-    matches_header "Set-Cookie", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "Set-Cookie", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/barracuda.cr
+++ b/src/wafalyzer/wafs/barracuda.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Barracuda < Waf
-    product "Barracuda Web Application Firewall (Barracuda Networks)"
+    register product: "Barracuda Web Application Firewall (Barracuda Networks)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/bekchy.cr
+++ b/src/wafalyzer/wafs/bekchy.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /(http(s)?:\/\/)(www.)?bekchy.com(\/report)?/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/bekchy.cr
+++ b/src/wafalyzer/wafs/bekchy.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Bekchy < Waf
-    product "Bekchy (WAF)"
+    register product: "Bekchy (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/bigip.cr
+++ b/src/wafalyzer/wafs/bigip.cr
@@ -12,6 +12,8 @@ module Wafalyzer
         /bigipserver/i,
       )
 
-    matches_header %w(Server Set-Cookie Cookie), PATTERN
+    builder do
+      matches_header %w(Server Set-Cookie Cookie), PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/bigip.cr
+++ b/src/wafalyzer/wafs/bigip.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::BigIP < Waf
-    product "BIG-IP (F5 Networks)"
+    register product: "BIG-IP (F5 Networks)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/binarysec.cr
+++ b/src/wafalyzer/wafs/binarysec.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::BinarySEC < Waf
-    product "BinarySEC Web Application Firewall (BinarySEC)"
+    register product: "BinarySEC Web Application Firewall (BinarySEC)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/binarysec.cr
+++ b/src/wafalyzer/wafs/binarysec.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /\bbinarysec\b/i,
       )
 
-    matches_any_header PATTERN
+    builder do
+      matches_any_header PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/bitninja.cr
+++ b/src/wafalyzer/wafs/bitninja.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::BitNinja < Waf
-    product "BitNinja (WAF)"
+    register product: "BitNinja (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/bitninja.cr
+++ b/src/wafalyzer/wafs/bitninja.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /.>visitor.anti(\S)?robot.validation<./i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/blockdos.cr
+++ b/src/wafalyzer/wafs/blockdos.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::BlockDos < Waf
-    product "BlockDos DDoS protection (BlockDos)"
+    register product: "BlockDos DDoS protection (BlockDos)"
 
     PATTERN =
       /blockdos\.net/i

--- a/src/wafalyzer/wafs/blockdos.cr
+++ b/src/wafalyzer/wafs/blockdos.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /blockdos\.net/i
 
-    matches_header "Server", PATTERN
+    builder do
+      matches_header "Server", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/chuangyu.cr
+++ b/src/wafalyzer/wafs/chuangyu.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /(http(s)?.\/\/(www.)?)?365cyd.(com|net)/i
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/chuangyu.cr
+++ b/src/wafalyzer/wafs/chuangyu.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Chuangyu < Waf
-    product "Chuangyu top government cloud defense platform (WAF)"
+    register product: "Chuangyu top government cloud defense platform (WAF)"
 
     PATTERN =
       /(http(s)?.\/\/(www.)?)?365cyd.(com|net)/i

--- a/src/wafalyzer/wafs/ciscoace.cr
+++ b/src/wafalyzer/wafs/ciscoace.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /ace.xml.gateway/i
 
-    matches_header "Server", PATTERN
+    builder do
+      matches_header "Server", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/ciscoace.cr
+++ b/src/wafalyzer/wafs/ciscoace.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::CiscoACE < Waf
-    product "Cisco ACE XML Firewall (Cisco)"
+    register product: "Cisco ACE XML Firewall (Cisco)"
 
     PATTERN =
       /ace.xml.gateway/i

--- a/src/wafalyzer/wafs/cloudflare.cr
+++ b/src/wafalyzer/wafs/cloudflare.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::CloudFlare < Waf
-    product "CloudFlare Web Application Firewall (CloudFlare)"
+    register product: "CloudFlare Web Application Firewall (CloudFlare)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/cloudflare.cr
+++ b/src/wafalyzer/wafs/cloudflare.cr
@@ -13,10 +13,12 @@ module Wafalyzer
         /ray.id/i,
       )
 
-    matches_header %w(CF-Cache-Status CF-Ray CF-Request-ID)
-    matches_header %w(Set-Cookie), /__cfduid/
-    matches_header %w(Expect-CT), /cloudflare/
-    matches_header %w(Server Cookie Set-Cookie Expect-CT), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(CF-Cache-Status CF-Ray CF-Request-ID)
+      matches_header %w(Set-Cookie), /__cfduid/
+      matches_header %w(Expect-CT), /cloudflare/
+      matches_header %w(Server Cookie Set-Cookie Expect-CT), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/cloudfront.cr
+++ b/src/wafalyzer/wafs/cloudfront.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /x.amz.cf.id|nguardx/i,
       )
 
-    matches_any_header_value PATTERN
+    builder do
+      matches_any_header_value PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/cloudfront.cr
+++ b/src/wafalyzer/wafs/cloudfront.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::CloudFront < Waf
-    product "CloudFront Firewall (Amazon)"
+    register product: "CloudFront Firewall (Amazon)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/codeigniter.cr
+++ b/src/wafalyzer/wafs/codeigniter.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::CodeIgniter < Waf
-    product "XSS/CSRF Filtering Protection (CodeIgniter)"
+    register product: "XSS/CSRF Filtering Protection (CodeIgniter)"
 
     PATTERN =
       /the.uri.you.submitted.has.disallowed.characters/i

--- a/src/wafalyzer/wafs/codeigniter.cr
+++ b/src/wafalyzer/wafs/codeigniter.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /the.uri.you.submitted.has.disallowed.characters/i
 
-    valid_status :bad_request
-    matches_body PATTERN
+    builder do
+      valid_status :bad_request
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/comodo.cr
+++ b/src/wafalyzer/wafs/comodo.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Comodo < Waf
-    product "Comodo Web Application Firewall (Comodo)"
+    register product: "Comodo Web Application Firewall (Comodo)"
 
     PATTERN =
       /protected.by.comodo.waf/i

--- a/src/wafalyzer/wafs/comodo.cr
+++ b/src/wafalyzer/wafs/comodo.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /protected.by.comodo.waf/i
 
-    matches_header "Server", PATTERN
+    builder do
+      matches_header "Server", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/configserver.cr
+++ b/src/wafalyzer/wafs/configserver.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ConfigServer < Waf
-    product "CSF (ConfigServer Security & Firewall)"
+    register product: "CSF (ConfigServer Security & Firewall)"
 
     PATTERN =
       /.>the.firewall.on.this.server.is.blocking.your.connection.<+/i

--- a/src/wafalyzer/wafs/configserver.cr
+++ b/src/wafalyzer/wafs/configserver.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /.>the.firewall.on.this.server.is.blocking.your.connection.<+/i
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/datapower.cr
+++ b/src/wafalyzer/wafs/datapower.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /\A(ok|fail)/i
 
-    matches_header "X-Backside-Trans", PATTERN
+    builder do
+      matches_header "X-Backside-Trans", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/datapower.cr
+++ b/src/wafalyzer/wafs/datapower.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DataPower < Waf
-    product "IBM Websphere DataPower Firewall (IBM)"
+    register product: "IBM Websphere DataPower Firewall (IBM)"
 
     PATTERN =
       /\A(ok|fail)/i

--- a/src/wafalyzer/wafs/denyall.cr
+++ b/src/wafalyzer/wafs/denyall.cr
@@ -2,7 +2,9 @@ module Wafalyzer
   class Waf::DenyAll < Waf
     register product: "Deny All Web Application Firewall (DenyAll)"
 
-    matches_header "Set-Cookie", /\Asessioncookie=/i
-    matches_body /\Acondition.intercepted/i
+    builder do
+      matches_header "Set-Cookie", /\Asessioncookie=/i
+      matches_body /\Acondition.intercepted/i
+    end
   end
 end

--- a/src/wafalyzer/wafs/denyall.cr
+++ b/src/wafalyzer/wafs/denyall.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DenyAll < Waf
-    product "Deny All Web Application Firewall (DenyAll)"
+    register product: "Deny All Web Application Firewall (DenyAll)"
 
     matches_header "Set-Cookie", /\Asessioncookie=/i
     matches_body /\Acondition.intercepted/i

--- a/src/wafalyzer/wafs/didiyun.cr
+++ b/src/wafalyzer/wafs/didiyun.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DiDiYun < Waf
-    product "DiDiYun WAF (DiDi)"
+    register product: "DiDiYun WAF (DiDi)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/didiyun.cr
+++ b/src/wafalyzer/wafs/didiyun.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /didiyun/i,
       )
 
-    matches_header "Server", "DiDi-SLB"
-    matches_body PATTERN
+    builder do
+      matches_header "Server", "DiDi-SLB"
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/dodenterpriseprotection.cr
+++ b/src/wafalyzer/wafs/dodenterpriseprotection.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /dod.enterprise.level.protection.system/i
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/dodenterpriseprotection.cr
+++ b/src/wafalyzer/wafs/dodenterpriseprotection.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DodEnterpriseProtection < Waf
-    product "DoD Enterprise-Level Protection System (Department of Defense)"
+    register product: "DoD Enterprise-Level Protection System (Department of Defense)"
 
     PATTERN =
       /dod.enterprise.level.protection.system/i

--- a/src/wafalyzer/wafs/dosarrest.cr
+++ b/src/wafalyzer/wafs/dosarrest.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DosArrest < Waf
-    product "DOSarrest (DOSarrest Internet Security)"
+    register product: "DOSarrest (DOSarrest Internet Security)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/dosarrest.cr
+++ b/src/wafalyzer/wafs/dosarrest.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /x.dis.request.id/i,
       )
 
-    matches_any_header PATTERN
+    builder do
+      matches_any_header PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/dotdefender.cr
+++ b/src/wafalyzer/wafs/dotdefender.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /dotdefender.blocked.your.request/i
 
-    matches_header "X-dotDefender-Denied"
-    matches_body PATTERN
+    builder do
+      matches_header "X-dotDefender-Denied"
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/dotdefender.cr
+++ b/src/wafalyzer/wafs/dotdefender.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DotDefender < Waf
-    product "dotDefender (Applicure Technologies)"
+    register product: "dotDefender (Applicure Technologies)"
 
     PATTERN =
       /dotdefender.blocked.your.request/i

--- a/src/wafalyzer/wafs/dynamicweb.cr
+++ b/src/wafalyzer/wafs/dynamicweb.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::DynamicWeb < Waf
-    product "DynamicWeb Injection Check (DynamicWeb)"
+    register product: "DynamicWeb Injection Check (DynamicWeb)"
 
     PATTERN =
       /dw.inj.check/i

--- a/src/wafalyzer/wafs/dynamicweb.cr
+++ b/src/wafalyzer/wafs/dynamicweb.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /dw.inj.check/i
 
-    valid_status :forbidden
-    matches_header "X-403-Status-By", PATTERN
+    builder do
+      valid_status :forbidden
+      matches_header "X-403-Status-By", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/edgecast.cr
+++ b/src/wafalyzer/wafs/edgecast.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /\Aecdf/i
 
-    matches_header "Server", PATTERN
+    builder do
+      matches_header "Server", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/edgecast.cr
+++ b/src/wafalyzer/wafs/edgecast.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::EdgeCast < Waf
-    product "EdgeCast Web Application Firewall (Verizon)"
+    register product: "EdgeCast Web Application Firewall (Verizon)"
 
     PATTERN =
       /\Aecdf/i

--- a/src/wafalyzer/wafs/expressionengine.cr
+++ b/src/wafalyzer/wafs/expressionengine.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /invalid.get.data/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/expressionengine.cr
+++ b/src/wafalyzer/wafs/expressionengine.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ExpressionEngine < Waf
-    product "ExpressionEngine (Ellislab WAF)"
+    register product: "ExpressionEngine (Ellislab WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/fortigate.cr
+++ b/src/wafalyzer/wafs/fortigate.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::FortiGate < Waf
-    product "FortiWeb Web Application Firewall (Fortinet)"
+    register product: "FortiWeb Web Application Firewall (Fortinet)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/fortigate.cr
+++ b/src/wafalyzer/wafs/fortigate.cr
@@ -16,7 +16,9 @@ module Wafalyzer
         /the.page.cannot.be.displayed..please.contact.[^@]+@[^@]+\.[^@]+.for.additional.information/i,
       )
 
-    matches_header "Set-Cookie", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "Set-Cookie", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/gladius.cr
+++ b/src/wafalyzer/wafs/gladius.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Gladius < Waf
-    product "Gladius network WAF (Gladius)"
+    register product: "Gladius network WAF (Gladius)"
 
     matches_header "gladius_blockchain_driven_cyber_protection_network_session"
   end

--- a/src/wafalyzer/wafs/gladius.cr
+++ b/src/wafalyzer/wafs/gladius.cr
@@ -2,6 +2,8 @@ module Wafalyzer
   class Waf::Gladius < Waf
     register product: "Gladius network WAF (Gladius)"
 
-    matches_header "gladius_blockchain_driven_cyber_protection_network_session"
+    builder do
+      matches_header "gladius_blockchain_driven_cyber_protection_network_session"
+    end
   end
 end

--- a/src/wafalyzer/wafs/googlewebservices.cr
+++ b/src/wafalyzer/wafs/googlewebservices.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::GoogleWebServices < Waf
-    product "Google Web Services (G-Cloud)"
+    register product: "Google Web Services (G-Cloud)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/googlewebservices.cr
+++ b/src/wafalyzer/wafs/googlewebservices.cr
@@ -9,9 +9,11 @@ module Wafalyzer
         /block(ed)?.by.g.cloud.security.policy.+/i,
       )
 
-    valid_status :bad_request
-    valid_status :too_many_requests
-    valid_status :internal_server_error
-    matches_body PATTERN
+    builder do
+      valid_status :bad_request
+      valid_status :too_many_requests
+      valid_status :internal_server_error
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/greywizard.cr
+++ b/src/wafalyzer/wafs/greywizard.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::GreyWizard < Waf
-    product "Grey Wizard Protection"
+    register product: "Grey Wizard Protection"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/greywizard.cr
+++ b/src/wafalyzer/wafs/greywizard.cr
@@ -10,7 +10,9 @@ module Wafalyzer
         /grey.wizard/,
       )
 
-    matches_header %w(GW-Server Server), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(GW-Server Server), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/incapsula.cr
+++ b/src/wafalyzer/wafs/incapsula.cr
@@ -9,7 +9,9 @@ module Wafalyzer
         /incapsula.incident.id/i,
       )
 
-    matches_header %w(Set-Cookie X-CDN), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(Set-Cookie X-CDN), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/incapsula.cr
+++ b/src/wafalyzer/wafs/incapsula.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Incapsula < Waf
-    product "Incapsula Web Application Firewall (Incapsula/Imperva)"
+    register product: "Incapsula Web Application Firewall (Incapsula/Imperva)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/infosafe.cr
+++ b/src/wafalyzer/wafs/infosafe.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Infosafe < Waf
-    product "INFOSAFE by http://7i24.com"
+    register product: "INFOSAFE by http://7i24.com"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/infosafe.cr
+++ b/src/wafalyzer/wafs/infosafe.cr
@@ -10,7 +10,9 @@ module Wafalyzer
         /var.infosafekey=/i,
       )
 
-    matches_header "Server", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "Server", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/instart.cr
+++ b/src/wafalyzer/wafs/instart.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Instart < Waf
-    product "Instart Logic (Palo Alto)"
+    register product: "Instart Logic (Palo Alto)"
 
     PATTERN =
       /instartrequestid/i

--- a/src/wafalyzer/wafs/instart.cr
+++ b/src/wafalyzer/wafs/instart.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /instartrequestid/i
 
-    matches_header %w(X-Instart-Request-ID X-Instart-CacheKeyMod)
-    matches_body PATTERN
+    builder do
+      matches_header %w(X-Instart-Request-ID X-Instart-CacheKeyMod)
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/janusec.cr
+++ b/src/wafalyzer/wafs/janusec.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Janusec < Waf
-    product "Janusec Application Gateway (WAF)"
+    register product: "Janusec Application Gateway (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/janusec.cr
+++ b/src/wafalyzer/wafs/janusec.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /(http(s)?\W+(www.)?)?janusec.(com|net|org)/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/jiasule.cr
+++ b/src/wafalyzer/wafs/jiasule.cr
@@ -10,7 +10,9 @@ module Wafalyzer
         /(static|www|dynamic).jiasule.(com|net)/i,
       )
 
-    matches_header %w(Server Set-Cookie), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(Server Set-Cookie), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/jiasule.cr
+++ b/src/wafalyzer/wafs/jiasule.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Jiasule < Waf
-    product "Jiasule (WAF)"
+    register product: "Jiasule (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/litespeed.cr
+++ b/src/wafalyzer/wafs/litespeed.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::LiteSpeed < Waf
-    product "LiteSpeed Generic Protection"
+    register product: "LiteSpeed Generic Protection"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/litespeed.cr
+++ b/src/wafalyzer/wafs/litespeed.cr
@@ -7,6 +7,8 @@ module Wafalyzer
         /litespeed.web.server/i
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/malcare.cr
+++ b/src/wafalyzer/wafs/malcare.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /.>firewall<.+.><.+>powered.by<.+.>(<.+.>)?(.?malcare.-.pro|blogvault)?/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/malcare.cr
+++ b/src/wafalyzer/wafs/malcare.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::MalCare < Waf
-    product "MalCare (MalCare Security WAF)"
+    register product: "MalCare (MalCare Security WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/modsecurity.cr
+++ b/src/wafalyzer/wafs/modsecurity.cr
@@ -12,6 +12,8 @@ module Wafalyzer
         /blocked.by.mod.security/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/modsecurity.cr
+++ b/src/wafalyzer/wafs/modsecurity.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ModSecurity < Waf
-    product "Open Source Web Application Firewall (ModSecurity)"
+    register product: "Open Source Web Application Firewall (ModSecurity)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/modsecurityowasp.cr
+++ b/src/wafalyzer/wafs/modsecurityowasp.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /additionally\S.a.406.not.acceptable/i,
       )
 
-    valid_status :not_acceptable
-    matches_body PATTERN
+    builder do
+      valid_status :not_acceptable
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/modsecurityowasp.cr
+++ b/src/wafalyzer/wafs/modsecurityowasp.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ModSecurityOWASP < Waf
-    product "OWASP ModSecurity Core Rule Set (CRS)"
+    register product: "OWASP ModSecurity Core Rule Set (CRS)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/nexusguard.cr
+++ b/src/wafalyzer/wafs/nexusguard.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /((http(s)?:\/\/)?speresources.)?nexusguard.com.wafpage/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/nexusguard.cr
+++ b/src/wafalyzer/wafs/nexusguard.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::NexusGuard < Waf
-    product "NexusGuard Security (WAF)"
+    register product: "NexusGuard Security (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/nginx.cr
+++ b/src/wafalyzer/wafs/nginx.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /you.do(not|n.t)?.have.permission.to.access.this.document/,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/nginx.cr
+++ b/src/wafalyzer/wafs/nginx.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Nginx < Waf
-    product "Nginx Generic Protection"
+    register product: "Nginx Generic Protection"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/paloalto.cr
+++ b/src/wafalyzer/wafs/paloalto.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::PaloAlto < Waf
-    product "Palo Alto Firewall (Palo Alto Networks)"
+    register product: "Palo Alto Firewall (Palo Alto Networks)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/paloalto.cr
+++ b/src/wafalyzer/wafs/paloalto.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /.>Virus.Spyware.Download.Blocked<./,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/perimeterx.cr
+++ b/src/wafalyzer/wafs/perimeterx.cr
@@ -10,6 +10,8 @@ module Wafalyzer
         /(..)?client.perimeterx.*\/[a-zA-Z]{8,15}\/*.*.js/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/perimeterx.cr
+++ b/src/wafalyzer/wafs/perimeterx.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::PerimeterX < Waf
-    product "Anti Bot Protection (PerimeterX)"
+    register product: "Anti Bot Protection (PerimeterX)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/pk.cr
+++ b/src/wafalyzer/wafs/pk.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::PKSecurityModule < Waf
-    product "pkSecurityModule (IDS)"
+    register product: "pkSecurityModule (IDS)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/pk.cr
+++ b/src/wafalyzer/wafs/pk.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /.>A.safety.critical.request.was.discovered.and.blocked.<./i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/powerful.cr
+++ b/src/wafalyzer/wafs/powerful.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /http(s)?...tiny.cc.powerful.firewall/i,
       )
 
-    valid_status :forbidden
-    matches_body PATTERN
+    builder do
+      valid_status :forbidden
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/powerful.cr
+++ b/src/wafalyzer/wafs/powerful.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Powerful < Waf
-    product "Powerful Firewall (MyBB plugin)"
+    register product: "Powerful Firewall (MyBB plugin)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/radware.cr
+++ b/src/wafalyzer/wafs/radware.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /with.the.following.case.number.in.its.subject:.\d+./i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/radware.cr
+++ b/src/wafalyzer/wafs/radware.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Radware < Waf
-    product "Radware (AppWall WAF)"
+    register product: "Radware (AppWall WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/rsfirewall.cr
+++ b/src/wafalyzer/wafs/rsfirewall.cr
@@ -10,6 +10,8 @@ module Wafalyzer
         /rsfirewall/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/rsfirewall.cr
+++ b/src/wafalyzer/wafs/rsfirewall.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::RSFirewall < Waf
-    product "RSFirewall (Joomla WAF)"
+    register product: "RSFirewall (Joomla WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/sabre.cr
+++ b/src/wafalyzer/wafs/sabre.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /dxsupport@sabre.com/i
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/sabre.cr
+++ b/src/wafalyzer/wafs/sabre.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Sabre < Waf
-    product "Sabre Firewall (WAF)"
+    register product: "Sabre Firewall (WAF)"
 
     PATTERN =
       /dxsupport@sabre.com/i

--- a/src/wafalyzer/wafs/safedog.cr
+++ b/src/wafalyzer/wafs/safedog.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::SafeDog < Waf
-    product "SafeDog WAF (SafeDog)"
+    register product: "SafeDog WAF (SafeDog)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/safedog.cr
+++ b/src/wafalyzer/wafs/safedog.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /waf(.?\d+.?\d+)/i,
       )
 
-    matches_header "X-Powered-By", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "X-Powered-By", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/secupress.cr
+++ b/src/wafalyzer/wafs/secupress.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /block.id.{1,2}bad.url.contents.<./i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/secupress.cr
+++ b/src/wafalyzer/wafs/secupress.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::SecuPress < Waf
-    product "SecuPress (Wordpress WAF)"
+    register product: "SecuPress (Wordpress WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/securesphere.cr
+++ b/src/wafalyzer/wafs/securesphere.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::SecureSphere < Waf
-    product "Imperva SecureSphere"
+    register product: "Imperva SecureSphere"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/shadowdaemon.cr
+++ b/src/wafalyzer/wafs/shadowdaemon.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ShadowDaemon < Waf
-    product "Shadow Daemon Opensource (WAF)"
+    register product: "Shadow Daemon Opensource (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/shadowdaemon.cr
+++ b/src/wafalyzer/wafs/shadowdaemon.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /request.forbidden.by.administrative.rules./i,
       )
 
-    valid_status :forbidden
-    matches_body PATTERN
+    builder do
+      valid_status :forbidden
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/shieldsecurity.cr
+++ b/src/wafalyzer/wafs/shieldsecurity.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /url.{1,2}form.or.cookie.data.wasn.t.appropriate/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/shieldsecurity.cr
+++ b/src/wafalyzer/wafs/shieldsecurity.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::ShieldSecurity < Waf
-    product "Shield Security"
+    register product: "Shield Security"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/siteguard.cr
+++ b/src/wafalyzer/wafs/siteguard.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /refuse.to.browse/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/siteguard.cr
+++ b/src/wafalyzer/wafs/siteguard.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::SiteGuard < Waf
-    product "SiteGuard Lite (Wordpress WAF)"
+    register product: "SiteGuard Lite (Wordpress WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/sonicwall.cr
+++ b/src/wafalyzer/wafs/sonicwall.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::SonicWALL < Waf
-    product "SonicWALL Firewall (Dell)"
+    register product: "SonicWALL Firewall (Dell)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/sonicwall.cr
+++ b/src/wafalyzer/wafs/sonicwall.cr
@@ -11,7 +11,9 @@ module Wafalyzer
         /.>policy.this.site.is.blocked<./i,
       )
 
-    matches_header "Server", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "Server", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/squid.cr
+++ b/src/wafalyzer/wafs/squid.cr
@@ -8,9 +8,11 @@ module Wafalyzer
         /X.Squid.Error/i,
       )
 
-    matches_header "eventsquid-id"
-    matches_any_header /squid/i
-    matches_any_header PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "eventsquid-id"
+      matches_any_header /squid/i
+      matches_any_header PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/squid.cr
+++ b/src/wafalyzer/wafs/squid.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Squid < Waf
-    product "Squid Proxy (IDS)"
+    register product: "Squid Proxy (IDS)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/stackpath.cr
+++ b/src/wafalyzer/wafs/stackpath.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /<h2>sorry,.you.have.been.blocked.?<.h2>/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/stackpath.cr
+++ b/src/wafalyzer/wafs/stackpath.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Stackpath < Waf
-    product "Stackpath WAF (StackPath)"
+    register product: "Stackpath WAF (StackPath)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/stingray.cr
+++ b/src/wafalyzer/wafs/stingray.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Stingray < Waf
-    product "Stingray Application Firewall (Riverbed/Brocade)"
+    register product: "Stingray Application Firewall (Riverbed/Brocade)"
 
     PATTERN =
       /\AX-Mapping-/i

--- a/src/wafalyzer/wafs/stingray.cr
+++ b/src/wafalyzer/wafs/stingray.cr
@@ -5,8 +5,10 @@ module Wafalyzer
     PATTERN =
       /\AX-Mapping-/i
 
-    valid_status :forbidden
-    valid_status :internal_server_error
-    matches_header "Set-Cookie", PATTERN
+    builder do
+      valid_status :forbidden
+      valid_status :internal_server_error
+      matches_header "Set-Cookie", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/stricthttp.cr
+++ b/src/wafalyzer/wafs/stricthttp.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /the.request.was.rejected.because.the.url.contained.a.potentially.malicious.string/i
 
-    valid_status :internal_server_error
-    matches_body PATTERN
+    builder do
+      valid_status :internal_server_error
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/stricthttp.cr
+++ b/src/wafalyzer/wafs/stricthttp.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::StrictHttpFirewall < Waf
-    product "StrictHttpFirewall (WAF)"
+    register product: "StrictHttpFirewall (WAF)"
 
     PATTERN =
       /the.request.was.rejected.because.the.url.contained.a.potentially.malicious.string/i

--- a/src/wafalyzer/wafs/sucuri.cr
+++ b/src/wafalyzer/wafs/sucuri.cr
@@ -10,8 +10,10 @@ module Wafalyzer
         /http(s)?.\/\/(cdn|supportx.)?sucuri(.net|com)?/i,
       )
 
-    matches_header "X-Sucuri-Block"
-    matches_header "Server", "Sucuri/Cloudproxy"
-    matches_body PATTERN
+    builder do
+      matches_header "X-Sucuri-Block"
+      matches_header "Server", "Sucuri/Cloudproxy"
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/sucuri.cr
+++ b/src/wafalyzer/wafs/sucuri.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Sucuri < Waf
-    product "Sucuri Firewall (Sucuri Cloudproxy)"
+    register product: "Sucuri Firewall (Sucuri Cloudproxy)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/teros.cr
+++ b/src/wafalyzer/wafs/teros.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Teros < Waf
-    product "Teros Web Application Firewall (Citrix)"
+    register product: "Teros Web Application Firewall (Citrix)"
 
     PATTERN =
       /st8(id|.wa|.wf)?.?(\d+|\w+)?/i

--- a/src/wafalyzer/wafs/teros.cr
+++ b/src/wafalyzer/wafs/teros.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /st8(id|.wa|.wf)?.?(\d+|\w+)?/i
 
-    matches_any_header_value PATTERN
+    builder do
+      matches_any_header_value PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/uewaf.cr
+++ b/src/wafalyzer/wafs/uewaf.cr
@@ -8,6 +8,8 @@ module Wafalyzer
         /uewaf(.deny.pages)/i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/uewaf.cr
+++ b/src/wafalyzer/wafs/uewaf.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::UEWaf < Waf
-    product "UEWaf (UCloud)"
+    register product: "UEWaf (UCloud)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/urlscan.cr
+++ b/src/wafalyzer/wafs/urlscan.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /rejected.by.url.scan/i
 
-    matches_header "Location", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "Location", PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/urlscan.cr
+++ b/src/wafalyzer/wafs/urlscan.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::URLScan < Waf
-    product "URLScan (Microsoft)"
+    register product: "URLScan (Microsoft)"
 
     PATTERN =
       /rejected.by.url.scan/i

--- a/src/wafalyzer/wafs/varnish.cr
+++ b/src/wafalyzer/wafs/varnish.cr
@@ -11,8 +11,10 @@ module Wafalyzer
         /.>access.is.blocked.according.to.our.site.security.policy.<+/i,
       )
 
-    matches_header %w(X-Varnish X-Cachewall-Action X-Cachewall-Reason)
-    matches_header %w(Server Via), PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header %w(X-Varnish X-Cachewall-Action X-Cachewall-Reason)
+      matches_header %w(Server Via), PATTERN
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/varnish.cr
+++ b/src/wafalyzer/wafs/varnish.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Varnish < Waf
-    product "Varnish/CacheWall WAF"
+    register product: "Varnish/CacheWall WAF"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/viettel.cr
+++ b/src/wafalyzer/wafs/viettel.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Viettel < Waf
-    product "Viettel WAF (Cloudrity)"
+    register product: "Viettel WAF (Cloudrity)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/viettel.cr
+++ b/src/wafalyzer/wafs/viettel.cr
@@ -10,6 +10,8 @@ module Wafalyzer
         /(http(s).\/\/)?cloudrity.com(.vn)?/
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/wallarm.cr
+++ b/src/wafalyzer/wafs/wallarm.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Wallarm < Waf
-    product "Wallarm WAF"
+    register product: "Wallarm WAF"
 
     PATTERN =
       /nginix.wallarm/

--- a/src/wafalyzer/wafs/wallarm.cr
+++ b/src/wafalyzer/wafs/wallarm.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /nginix.wallarm/
 
-    matches_header "Server", PATTERN
+    builder do
+      matches_header "Server", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/watchguard.cr
+++ b/src/wafalyzer/wafs/watchguard.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::WatchGuard < Waf
-    product "WatchGuard WAF"
+    register product: "WatchGuard WAF"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/watchguard.cr
+++ b/src/wafalyzer/wafs/watchguard.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /watchguard(.technologies(.inc)?)?/i,
       )
 
-    matches_header "Server", /watchguard/i
-    matches_body PATTERN
+    builder do
+      matches_header "Server", /watchguard/i
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/webknight.cr
+++ b/src/wafalyzer/wafs/webknight.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::WebKnight < Waf
-    product "WebKnight Application Firewall (AQTRONIX)"
+    register product: "WebKnight Application Firewall (AQTRONIX)"
 
     PATTERN =
       /webknight/i

--- a/src/wafalyzer/wafs/webknight.cr
+++ b/src/wafalyzer/wafs/webknight.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /webknight/i
 
-    matches_header "Server", PATTERN
+    builder do
+      matches_header "Server", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/webseal.cr
+++ b/src/wafalyzer/wafs/webseal.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /webseal.server.received.an.invalid.http.request/i,
       )
 
-    matches_header "Server", "WebSEAL"
-    matches_body PATTERN
+    builder do
+      matches_header "Server", "WebSEAL"
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/webseal.cr
+++ b/src/wafalyzer/wafs/webseal.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::WebSEAL < Waf
-    product "IBM Security Access Manager (WebSEAL)"
+    register product: "IBM Security Access Manager (WebSEAL)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/west263.cr
+++ b/src/wafalyzer/wafs/west263.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /wt\d*cdn/i
 
-    matches_header "X-Cache", PATTERN
+    builder do
+      matches_header "X-Cache", PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/west263.cr
+++ b/src/wafalyzer/wafs/west263.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::West236 < Waf
-    product "West236 Firewall"
+    register product: "West236 Firewall"
 
     PATTERN =
       /wt\d*cdn/i

--- a/src/wafalyzer/wafs/wordfence.cr
+++ b/src/wafalyzer/wafs/wordfence.cr
@@ -9,6 +9,8 @@ module Wafalyzer
         /.>wordfence<./i,
       )
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/wordfence.cr
+++ b/src/wafalyzer/wafs/wordfence.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Wordfence < Waf
-    product "Wordfence (Feedjit)"
+    register product: "Wordfence (Feedjit)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/wts.cr
+++ b/src/wafalyzer/wafs/wts.cr
@@ -5,6 +5,8 @@ module Wafalyzer
     PATTERN =
       /(<title>)?wts.wa(f)?(\w+(\w+(\w+)?)?)?/i
 
-    matches_body PATTERN
+    builder do
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/wts.cr
+++ b/src/wafalyzer/wafs/wts.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::WTS < Waf
-    product "WTS-WAF (Web Application Firewall)"
+    register product: "WTS-WAF (Web Application Firewall)"
 
     PATTERN =
       /(<title>)?wts.wa(f)?(\w+(\w+(\w+)?)?)?/i

--- a/src/wafalyzer/wafs/xuanwudun.cr
+++ b/src/wafalyzer/wafs/xuanwudun.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Xuanwudun < Waf
-    product "Xuanwudun WAF"
+    register product: "Xuanwudun WAF"
 
     PATTERN =
       /class=.(db)?waf.?(-row.)?>/i

--- a/src/wafalyzer/wafs/xuanwudun.cr
+++ b/src/wafalyzer/wafs/xuanwudun.cr
@@ -5,7 +5,9 @@ module Wafalyzer
     PATTERN =
       /class=.(db)?waf.?(-row.)?>/i
 
-    valid_status :forbidden
-    matches_body PATTERN
+    builder do
+      valid_status :forbidden
+      matches_body PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/yundun.cr
+++ b/src/wafalyzer/wafs/yundun.cr
@@ -10,7 +10,9 @@ module Wafalyzer
         /<title>.403.forbidden:.access.is.denied.{0,2}<.{0,2}title>/i,
       )
 
-    matches_header %w(X-Cache Server Set-Cookie), PATTERN
+    builder do
+      matches_header %w(X-Cache Server Set-Cookie), PATTERN
+    end
 
     def matches?(response : HTTP::Client::Response) : Bool
       if response.status.code == 461 && response.body? =~ PATTERN

--- a/src/wafalyzer/wafs/yundun.cr
+++ b/src/wafalyzer/wafs/yundun.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Yundun < Waf
-    product "Yundun Web Application Firewall (Yundun)"
+    register product: "Yundun Web Application Firewall (Yundun)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/yunsuo.cr
+++ b/src/wafalyzer/wafs/yunsuo.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Yunsuo < Waf
-    product "Yunsuo Web Application Firewall (Yunsuo)"
+    register product: "Yunsuo Web Application Firewall (Yunsuo)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/yunsuo.cr
+++ b/src/wafalyzer/wafs/yunsuo.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /yunsuo.session/i,
       )
 
-    matches_body PATTERN
-    matches_any_header_value PATTERN
+    builder do
+      matches_body PATTERN
+      matches_any_header_value PATTERN
+    end
   end
 end

--- a/src/wafalyzer/wafs/zscaler.cr
+++ b/src/wafalyzer/wafs/zscaler.cr
@@ -1,6 +1,6 @@
 module Wafalyzer
   class Waf::Zscaler < Waf
-    product "Zscaler Cloud Firewall (WAF)"
+    register product: "Zscaler Cloud Firewall (WAF)"
 
     PATTERN =
       Regex.union(

--- a/src/wafalyzer/wafs/zscaler.cr
+++ b/src/wafalyzer/wafs/zscaler.cr
@@ -8,7 +8,9 @@ module Wafalyzer
         /zscaler(.\d+(.\d+)?)?/i,
       )
 
-    matches_header "Server", PATTERN
-    matches_body PATTERN
+    builder do
+      matches_header "Server", PATTERN
+      matches_body PATTERN
+    end
   end
 end


### PR DESCRIPTION
Switch to using a single registry of preconfigured `Waf` instances instead of relying on @@class_variables.
This way the already configured instances can be further extended and rules can be modified in place, with no connection to the global instance.