### PR TITLE
Add option to disable ssl verification

### DIFF
--- a/src/cli.cr
+++ b/src/cli.cr
@@ -99,7 +99,7 @@ Wafalyzer.configure do |settings|
   settings.timeout = timeout
   settings.fallback_requests_count = fallback_requests_count
   settings.use_random_user_agent = use_random_user_agent
-  settings.disable_ssl_verifications = disable_ssl_verifications
+  settings.disable_ssl_verification = disable_ssl_verification
 end
 
 wafs = Wafalyzer.detect(

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -67,7 +67,7 @@ OptionParser.parse do |parser|
     use_random_user_agent = true
   end
 
-  parser.on "-s", "--disable-ssl-verify", "Disable SSL verification" do
+  parser.on "-s", "--disable-ssl-verify", "Disables SSL verification" do
     disable_ssl_verification = true
   end
 

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -67,8 +67,8 @@ OptionParser.parse do |parser|
     use_random_user_agent = true
   end
 
-  parser.on "-s", "--disable-ssl-verify", "Disable SSL verifications" do
-    disable_ssl_verifications = true
+  parser.on "-s", "--disable-ssl-verify", "Disable SSL verification" do
+    disable_ssl_verification = true
   end
 
   parser.on "-u VALUE", "--user-agent=VALUE", "Uses supplied user agent string" do |value|

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -28,7 +28,7 @@ timeout = nil
 fallback_requests_count = nil
 json = false
 use_random_user_agent = false
-disable_ssl_verifications = false
+disable_ssl_verification = false
 user_agent = nil
 
 OptionParser.parse do |parser|

--- a/src/cli.cr
+++ b/src/cli.cr
@@ -28,6 +28,7 @@ timeout = nil
 fallback_requests_count = nil
 json = false
 use_random_user_agent = false
+disable_ssl_verifications = false
 user_agent = nil
 
 OptionParser.parse do |parser|
@@ -66,6 +67,10 @@ OptionParser.parse do |parser|
     use_random_user_agent = true
   end
 
+  parser.on "-s", "--disable-ssl-verify", "Disable SSL verifications" do
+    disable_ssl_verifications = true
+  end
+
   parser.on "-u VALUE", "--user-agent=VALUE", "Uses supplied user agent string" do |value|
     user_agent = value
   end
@@ -94,6 +99,7 @@ Wafalyzer.configure do |settings|
   settings.timeout = timeout
   settings.fallback_requests_count = fallback_requests_count
   settings.use_random_user_agent = use_random_user_agent
+  settings.disable_ssl_verifications = disable_ssl_verifications
 end
 
 wafs = Wafalyzer.detect(

--- a/src/wafalyzer.cr
+++ b/src/wafalyzer.cr
@@ -21,6 +21,7 @@ module Wafalyzer
       port: port,
       tls: tls,
     )
+    client.tls.verify_mode=OpenSSL::SSL::VerifyMode::NONE if settings.disable_ssl_verifications?
 
     if timeout = settings.timeout
       client

--- a/src/wafalyzer.cr
+++ b/src/wafalyzer.cr
@@ -21,7 +21,7 @@ module Wafalyzer
       port: port,
       tls: tls,
     )
-    client.tls.verify_mode = :none if settings.disable_ssl_verification?
+    client.tls?.try(&.verify_mode = :none) if settings.disable_ssl_verification?
 
     if timeout = settings.timeout
       client

--- a/src/wafalyzer.cr
+++ b/src/wafalyzer.cr
@@ -21,7 +21,7 @@ module Wafalyzer
       port: port,
       tls: tls,
     )
-    client.tls.verify_mode=OpenSSL::SSL::VerifyMode::NONE if settings.disable_ssl_verifications?
+    client.tls.verify_mode = :none if settings.disable_ssl_verification?
 
     if timeout = settings.timeout
       client

--- a/src/wafalyzer/settings.cr
+++ b/src/wafalyzer/settings.cr
@@ -27,6 +27,9 @@ module Wafalyzer
     # `User-Agent` string from the `user_agents` array.
     class_property? use_random_user_agent = false
 
+    # Setting it to `true` will disable SSL verifications
+    class_property? disable_ssl_verifications = false
+
     # Returns `User-Agent` string, sampled from `user_agents` when the
     # `use_random_user_agent?` is set to `true`, or `default_user_agent`
     # otherwise.

--- a/src/wafalyzer/settings.cr
+++ b/src/wafalyzer/settings.cr
@@ -27,8 +27,8 @@ module Wafalyzer
     # `User-Agent` string from the `user_agents` array.
     class_property? use_random_user_agent = false
 
-    # Setting it to `true` will disable SSL verifications
-    class_property? disable_ssl_verifications = false
+    # Setting it to `true` will disable SSL verification
+    class_property? disable_ssl_verification = false
 
     # Returns `User-Agent` string, sampled from `user_agents` when the
     # `use_random_user_agent?` is set to `true`, or `default_user_agent`


### PR DESCRIPTION
In some cases the ssl verification fails

```
SSL_connect: error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed (OpenSSL::SSL::Error)
```
in some situations it is useful to deactivate verification