### PR TITLE
fix: matches_body crash on invalid encoding body

### DIFF
--- a/src/wafalyzer/waf/matcher.cr
+++ b/src/wafalyzer/waf/matcher.cr
@@ -69,11 +69,12 @@ module Wafalyzer
     end
 
     protected def matches_body?(response : HTTP::Client::Response) : Bool
+      return false unless body = response.body?
+      body = body.scrub unless body.valid_encoding?
       matches_body.try do |pattern|
-        if response.body? =~ pattern
+        if body.matches?(pattern)
           Log.debug &.emit("Found body match", {
             pattern: pattern.to_s,
-            matches: $~.to_a,
           })
           return true
         end


### PR DESCRIPTION
Before:
```
./bin/wafalyzer -m GET https://brokencrystals.com/favicons/apple-icon-57x57.png
Invalid memory access (signal 11) at address 0x7f1cb4cf12a0
[0x55597c7ee396] *Exception::CallStack::print_backtrace:(Int32 | Nil) +118
[0x55597c7d210a] ~procProc(Int32, Pointer(LibC::SiginfoT), Pointer(Void), Nil) +330
[0x7f1cb470a3c0] ???
[0x7f1cb487e5e7] ???
[0x7f1cb487dc83] ???
[0x7f1cb488d626] pcre_exec +2726
[0x55597c98a536] *Regex#internal_matches?<String, Int32, Regex::Options, Pointer(Int32), Int32>:Bool +166
[0x55597c98aad7] *Regex#match_at_byte_index<String, Int32, Regex::Options>:(Regex::MatchData | Nil) +439
[0x55597c98a75d] *Regex#match<String>:(Regex::MatchData | Nil) +189
[0x55597c81a3ef] *String#=~<Regex>:(Int32 | Nil) +47
[0x55597c986fed] *Wafalyzer::Waf+ +493
[0x55597c98496d] *Wafalyzer::Waf+ +109
[0x55597c97ac82] *Wafalyzer::Waf::detect<HTTP::Client::Response>:Array(Wafalyzer::Waf+) +690
[0x55597c9cdc4e] *Wafalyzer +190
[0x55597c9cd1f3] *Wafalyzer +307
[0x55597c9cd0b2] *Wafalyzer +82
[0x55597c7bf94c] __crystal_main +15644
[0x55597c9fd8d6] *Crystal::main_user_code<Int32, Pointer(Pointer(UInt8))>:Nil +6
[0x55597c9fd74c] *Crystal::main<Int32, Pointer(Pointer(UInt8))>:Int32 +44
[0x55597c7cb236] main +6
[0x7f1cb44b10b3] __libc_start_main +243
[0x55597c7bbb6e] _start +46
[0x0] ???
```
After: 
```
time ./bin/wafalyzer -m GET https://brokencrystals.com/favicons/apple-icon-57x57.png
No WAF detected

real	0m10,953s
user	0m0,679s
sys	0m0,027s
```