### PR TITLE
fix: remove false indication of WAF

### DIFF
--- a/src/wafalyzer/wafs/nginx.cr
+++ b/src/wafalyzer/wafs/nginx.cr
@@ -2,11 +2,7 @@ module Wafalyzer
   class Waf::Nginx < Waf
     register product: "Nginx Generic Protection"
 
-    PATTERN =
-      Regex.union(
-        /nginx/i,
-        /you.do(not|n.t)?.have.permission.to.access.this.document/,
-      )
+    PATTERN = /you.do(not|n.t)?.have.permission.to.access.this.document/
 
     builder do
       matches_body PATTERN


### PR DESCRIPTION
This line will match the word ngnix, this is in no way an indication that a WAF is active on the target.